### PR TITLE
ci: move `git diff` to the end of workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,20 +8,20 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2' ]
       fail-fast: false
 
     steps:
-      - name: Cache multiple paths
-        uses: actions/cache@v3
-        with:
-          path: $HOME/.composer/cache
-          key: '${{ runner.os }}-${{ hashFiles(''TODO'') }}'
       - uses: actions/checkout@v3
 
       - name: Setup PHP
@@ -30,6 +30,17 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2, wp-cli
           coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Run before install
         run: |
@@ -55,12 +66,11 @@ jobs:
       - name: Lint stubfile
         run: |
           php -l wp-graphql-stubs.php
-      
-      - name: Check for changes
-        run: |
-          git diff --exit-code
 
       - name: Run PHPStan
         run: |
           vendor/bin/phpstan
 
+      - name: Check for changes
+        run: |
+          git diff --exit-code


### PR DESCRIPTION
Moves the `git diff` action to the end of the CI workflow.

No reason to run an entire workflow just to `diff`, but unlike a php lint/stan error a diff is not necessarily "failing", just requires manual review. (see #3 for an example)