### PR TITLE
ci: manual rerelease trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ name: Release Latest Versions
 
 on:
   workflow_dispatch:
+    inputs:
+      should_rerelease:
+        description: 'Repack the latest version of the package'
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '0 */12 * * *'
 
@@ -20,5 +26,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          bash -x ./release-latest-versions.sh
+          if [ "${{ inputs.should_rerelease }}" = "true" ]; then
+            bash -x ./release-latest-versions.sh --should-rerelease
+          else
+            bash -x ./release-latest-versions.sh
+          fi
 

--- a/release-latest-versions.sh
+++ b/release-latest-versions.sh
@@ -12,10 +12,7 @@ do_release() {
 	local REPACK_VERSION="$2"
 	local SED_EXP
 	
-	# If VERSION starts with v, remove it.
-	if [ "${VERSION}" == "v${VERSION#v}" ]; then
-		VERSION="${VERSION#v}"
-	fi
+	VERSION="${VERSION#v}"
 
 	echo "Releasing v${VERSION}..."
 


### PR DESCRIPTION
This PR adds the option to manually trigger a rerelease for old versions. This is useful for when the generator itself changes (i.e. a PR to the repo like #3 ).

This is handled by appending a `+repack.{#}` to the tag, and then _deleting the old tag_ since we want to match the WPGraphQL versions, but SemVer doesnt give build meta and precedence.

As such, users who already have the package locally may need to install with --no-cache to get the repack, but this is IMO still better than only having fixes to the repo apply to future WPGraphQL stubs, when a major use case is using the stubfile to test _minimum_ version compatibility. 