### PR TITLE
ci: improve release handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
         required: false
         default: false
         type: boolean
+      dry_run:
+        description: 'Dry run: Run the script without pushing changes'
+        required: false
+        default: false
+        type: boolean
+      from_version:
+        description: 'The version to start from'
+        required: false
+        default: '1.0.0'
+        type: string
   schedule:
     - cron: '0 */12 * * *'
 
@@ -26,9 +36,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           if [ "${{ inputs.should_rerelease }}" = "true" ]; then
-            bash -x ./release-latest-versions.sh --should-rerelease
-          else
-            bash -x ./release-latest-versions.sh
+            SHOULD_RERELEASE="--should-rerelease"
           fi
+
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN="--dry-run"
+          fi
+
+          bash -x ./release-lastest-versions.sh $SHOULD_RERELEASE $DRY_RUN --from-version=${{ inputs.from_version }}
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ and see the `example` directory over there.
 
 This package is versioned to match the WPGraphQL version from which the stubs are generated.
 
+When changes are made to the actual stub generation that require a new release, the old release is _deleted_ and a new tag is created with the format `x.x.x+repack.y` where `x.x.x` is the WPGraphQL version and `y` is the the repack iteration. This is necessary because Composer's SemVer implementation ignores build meta when determining the latest version.
+
+If you already have an old build of the version installed, you will need to run `composer update --no-cache` to get the latest repack.
+
 ## Generating stubs for a different WPGraphQL version
 
 1. Clone this repository and `cd` into it.


### PR DESCRIPTION
This PR
- Adds the `dry_run` and `from_version` to the release CI.
- Test the version exists before updating composer and rebuilding.
- Adds a note about the build meta to the README.md