### PR TITLE
ci: improve repack handling in release script

### DIFF
--- a/release-latest-versions.sh
+++ b/release-latest-versions.sh
@@ -12,44 +12,54 @@ while [[ $# -gt 0 ]]; do
 	key="$1"
 
 	case $key in
-		--should-rerelease)
-			SHOULD_RERELEASE=true
-			shift
-			;;
-		--dry-run)
-			DRY_RUN=true
-			shift
-			;;
-		--from-version=*)
-			FROM_VERSION="${key#*=}"
-			shift
-			;;
-		*)
-			# unknown option
-			shift
-			;;
+	--should-rerelease)
+		SHOULD_RERELEASE=true
+		shift
+		;;
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	--from-version=*)
+		FROM_VERSION="${key#*=}"
+		shift
+		;;
+	*)
+		# unknown option
+		shift
+		;;
 	esac
 done
 
 do_release() {
-	local VERSION="$1"
-	local REPACK_VERSION="$2"
-	
+	local TAG="$1"
+	local IS_REPACK="${2:-false}"
+
+	# The version from the tag.
+	local VERSION="${TAG%%+repack.*}"
 	VERSION="${VERSION#v}"
 
-	echo "Checking if version ${VERSION} exists..."
+	# If IS_REPACK is true, get the repack version from the tag.
+	if [ "${IS_REPACK}" = true ]; then
+		REPACK_VERSION="${TAG#*+repack.}"
+		if [ "${REPACK_VERSION}" = "${TAG}" ]; then
+			REPACK_VERSION=0
+		fi
+	fi
+
+	echo "Checking if version ${VERSION} exists on Composer..."
 
 	# If the version doesn't exist, return
 	if ! composer show --working-dir=source --available wpackagist-plugin/wp-graphql "${VERSION}" >/dev/null 2>&1; then
-		echo "Version ${VERSION} does not exist"
+		echo "Version ${VERSION} does not exist. Skipping..."
 		return
 	fi
 
-	echo "Releasing v${VERSION}..."
+	echo "Building v${VERSION}"
 
 	# Replace the version of wpackagist-plugin/wp-graphql in composer.json with $VERSION
-	contents="$(jq --arg version "${VERSION}" '.require."wpackagist-plugin/wp-graphql" = $version' < source/composer.json)" \
-		&& echo "${contents}" > source/composer.json
+	contents="$(jq --arg version "${VERSION}" '.require."wpackagist-plugin/wp-graphql" = $version' <source/composer.json)" &&
+		echo "${contents}" >source/composer.json
 
 	cat source/composer.json
 
@@ -60,26 +70,27 @@ do_release() {
 	composer run-script generate
 
 	# Tag version
-	if [ -z "${REPACK_VERSION}" ]; then
-		echo "Tagging v${VERSION}"
-		git commit --all -m "Generate stubs for WPGraphQL v${VERSION}"
-		git tag "v${VERSION}"
+	if [ "${IS_REPACK}" = false ]; then
+		echo "Tagging ${TAG}"
+		git commit --all -m "Generate stubs for WPGraphQL ${TAG}"
+		git tag "${TAG}"
 	else
+		REPACK_VERSION=$((REPACK_VERSION + 1))
 		echo "Tagging v${VERSION}+repack.${REPACK_VERSION}"
 		git commit --all -m "Generating stubs for WPGraphQL v${VERSION}+repack.${REPACK_VERSION}"
 		git tag "v${VERSION}+repack.${REPACK_VERSION}"
 
-		# Delete the old git tag.
-		echo "Deleting old tag v${VERSION}"
-		git tag -d "v${VERSION}"
+		# Delete the old git tag locally.
+		echo "Deleting old tag locally..."
+		git tag -d "${TAG}"
 
 		# Delete the old tag on GitHub.
 		if [ -z "${DRY_RUN}" ]; then
-			git push --delete origin "v${VERSION}"
-			echo "Tag deleted from GitHub."
+			echo "Deleting old tag from Origin."
+			git push --delete origin "${TAG}"
 		fi
 	fi
-	
+
 	# Push to GitHub
 	if [ -z "${DRY_RUN}" ]; then
 		git push
@@ -100,13 +111,9 @@ printf -v JQ_FILTER '.package.versions[].version | select(. | startswith("v"))'
 # Sort the versions.
 POSSIBLE_VERSIONS="$(jq -r "$JQ_FILTER" <<<"$GQL_JSON" | sort -V)"
 
-# List all possible versions
-echo "Possible versions:"
-echo "${POSSIBLE_VERSIONS}"
-
 # Read latest version from composer.json if no FROM_VERSION is set.
 if [ -z "${FROM_VERSION}" ]; then
-	FROM_VERSION="$(jq -r '.require."wpackagist-plugin/wp-graphql"' < source/composer.json | sed -e 's/[^0-9.]*//g')"
+	FROM_VERSION="$(jq -r '.require."wpackagist-plugin/wp-graphql"' <source/composer.json | sed -e 's/[^0-9.]*//g')"
 fi
 
 # Loop through all possible versions and see if they exist as tags
@@ -118,28 +125,22 @@ for POSSIBLE_VERSION in ${POSSIBLE_VERSIONS}; do
 
 	echo "Checking ${POSSIBLE_VERSION}"
 
-	# If the tag exists, skip it or rerelease it.
-	if git rev-parse "refs/tags/${POSSIBLE_VERSION}" >/dev/null 2>&1; then
-		echo "Tag exists!"
+	# Get the latest tag that starts with POSSIBLE_VERSION
+	MATCHED_TAG="$(git tag --list "${POSSIBLE_VERSION}*" --sort=-v:refname | head -n 1)"
+
+	# If we matched a tag, check if we should rerelease it
+	if [ -n "${MATCHED_TAG}" ]; then
 
 		if [ -z "${SHOULD_RERELEASE}" ]; then
-			echo "Skipping"
+			echo "Tag exists as ${MATCHED_TAG}. Skipping..."
 			continue
 		fi
 
-		# If SHOULD_RERELEASE is true, append -r1, -r2, etc.
-		for REPACK in {1..100}; do
-			# If the tag doesn't exist, release it
-			if ! git rev-parse "refs/tags/${POSSIBLE_VERSION}+repack.${REPACK}" >/dev/null 2>&1; then
-				echo "Rereleasing as ${POSSIBLE_VERSION}+repack.${REPACK}"
-				do_release "${POSSIBLE_VERSION}" "${REPACK}"
-				break
-			fi
-		done
-
+		echo "Tag exists as ${MATCHED_TAG}. Rereleasing..."
+		do_release "${MATCHED_TAG}" true
 		continue
 	fi
 
 	# If the tag doesn't exist, release it
-	do_release "${POSSIBLE_VERSION}"
+	do_release "${POSSIBLE_VERSION}" false
 done

--- a/release-latest-versions.sh
+++ b/release-latest-versions.sh
@@ -126,7 +126,7 @@ for POSSIBLE_VERSION in ${POSSIBLE_VERSIONS}; do
 	echo "Checking ${POSSIBLE_VERSION}"
 
 	# Get the latest tag that starts with POSSIBLE_VERSION
-	MATCHED_TAG="$(git tag --list "${POSSIBLE_VERSION}*" --sort=-v:refname | head -n 1)"
+	MATCHED_TAG="$(git tag --list "${POSSIBLE_VERSION}^*" "${POSSIBLE_VERSION}+*" --sort=-v:refname | head -n 1)"
 
 	# If we matched a tag, check if we should rerelease it
 	if [ -n "${MATCHED_TAG}" ]; then


### PR DESCRIPTION
Refactors `release-latest-versions.sh` to better check/cleanup repack tags.

Fixes #12 